### PR TITLE
Update devroom name & description for 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-Testing and Automation devroom is coming again to
+Testing and Continuous Delivery devroom is coming again to
 [FOSDEM](https://fosdem.org/). This room is about building better
-software through a focus on testing and automation at all layers of
-the stack. From creating libraries and end-user applications all the
-way down to packaging, distribution and deployment. Testing and
-automation is not isolated to a single toolchain, language or
-platform, there is much to learn and share regardless of background!
+software through a focus on testing and continuous delivery practices
+across all layers of the stack. The purpose of this devroom is to
+share good and bad examples around the question
+“how to improve quality of our software by automating tests, deliveries or deployments”
+and to showcase new open source tools and practices.
+
+**Note:** for FOSDEM 2024 this devroom is a merger between the former
+*Testing and Automation* and *Continuous Integration and Continuous Deployment*
+devrooms and is jointly co-organized between devroom managers in previous FOSDEM editions!
 
 For more information, please see
 https://fosdem-testingautomation.github.io

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
     <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
 
-    <title>FOSDEM Testing and Automation Developer Room</title>
+    <title>FOSDEM 2024 Testing and Continuous Delivery Developer Room</title>
   </head>
 
   <body>
@@ -18,7 +18,7 @@
         <header class="inner">
           <a id="forkme_banner" href="https://github.com/fosdem-testingautomation">View on GitHub</a>
 
-          <h1 id="project_title">FOSDEM Testing and Automation Developer Room</h1>
+          <h1 id="project_title">FOSDEM 2024 Testing and Continuous Delivery Developer Room</h1>
           <h2 id="project_tagline"></h2>
 
         </header>
@@ -30,32 +30,45 @@
         <h1>
 <a name="why" class="anchor" href="#why"><span class="octicon octicon-link"></span></a>Why</h1>
 
-<p>Testing and Automation devroom is coming again to
+<p>Testing and Continuous Delivery devroom is coming again to
 <a href="https://fosdem.org/">FOSDEM</a>. This room is about building better
-software through a focus on testing and automation at all layers of
-the stack. From creating libraries and end-user applications all the
-way down to packaging, distribution and deployment. Testing and
-automation is not isolated to a single toolchain, language or
-platform, there is much to learn and share regardless of background!</p>
+software through a focus on testing and continuous delivery practices
+across all layers of the stack. The purpose of this devroom is to
+share good and bad examples around the question
+“how to improve quality of our software by automating tests, deliveries or deployments”
+and to showcase new open source tools and practices.
+
+<strong>Note:</strong> for FOSDEM 2024 this devroom is a merger between the former
+<em>Testing and Automation</em> and <em>Continuous Integration and Continuous Deployment</em>
+devrooms and is jointly co-organized between devroom managers in previous FOSDEM editions!
+</p>
 
 <h1>
 <a name="what" class="anchor" href="#what"><span class="octicon octicon-link"></span></a>What</h1>
 
-<p>Since Testing and Automation devroom has been a regular at FOSDEM, here are some
+<p>Since this devroom has been a regular at FOSDEM, here are some
 ideas of what we would like to see, and what worked in prior years, they&#39;re just
 ideas though. Check out the <a href="#archive">Archive</a> for inspiration.
 </p>
 <h3 id="testing-in-the-real-open-source-world">Testing in the real, open source world</h3>
 <ul>
+
 <li>War stories/strategies for testing large scale or complex projects</li>
-<li>Demistyfy resource e.g. systems/device/cloud provisioning in a CI loop</li>
 <li>Tools that extend the ability to test low-level code, e.g. bootloaders, init systems, etc.</li>
 <li>Projects that are introducing new/interesting ways of testing &quot;systems&quot;</li>
 <li>Address the automated testing frameworks fragmentation</li>
-<li>Lessons learned from testing</li>
+<li>Stories from end-users (e.g. success/failure)</li>
+<li>Continuous Integration</li>
+<li>Continuous Delivery</li>
+<li>Continuous Deployment</li>
+<li>Security in Software Supply Chain</li>
+<li>Pipeline standardization</li>
+<li>Interoperability in CI/CD</li>
+<li>Lessons learned</li>
 </ul>
 <h3 id="cool-tools-good-candidates-for-lightning-talks-">Cool Tools (good candidates for lightning talks)</h3>
 <ul>
+<li>Project showcases, modern tooling</li>
 <li>How your open source tool made developing quality software better</li>
 <li>What tools do you use to setup your CI/CD</li>
 <li>Combining projects/plugins/tools to build amazing things &quot;Not enough
@@ -115,10 +128,12 @@ FOSDEM 2024 will be hosted <strong>in person</strong> at
 
 
 <ul>
-<li><a href="https://github.com/atodorov">A. Todorov</a> - Kiwi TCMS, QA &amp; project lead</li>
-<li><a href="https://www.linkedin.com/in/zaklina-stojnev/">Z. Stojnev</a> - Kiwi TCMS, Test Engineer</li>
-<li><a href="https://github.com/roxell">A. Roxell</a> - Linaro, QA and Kernel Engineer</li>
-<li><a href="https://github.com/metan-ucw">C. Hrubis</a> - SUSE</li>
+<li><a href="https://github.com/atodorov">Alex Todorov</a> - Kiwi TCMS, QA &amp; project lead</li>
+<li><a href="https://github.com/roxell">Anders Roxell</a> - Linaro, QA and Kernel Engineer</li>
+<li><a href="https://github.com/metan-ucw">Cyril Hrubis</a> - SUSE</li>
+<li><a href="#">Fabrizio Manfredi</a> - </li>
+<li><a href="#">Jan Willies</a> - </li>
+<li><a href="https://github.com/olblak">Olivier Vernin</a> - SUSE</li>
 </ul>
 
 
@@ -126,16 +141,28 @@ FOSDEM 2024 will be hosted <strong>in person</strong> at
 
 <ul>
 <li><a href="https://fosdem.org/2024/schedule/track/testing-and-automation-devroom/">2024</a></li>
-<li><a href="https://archive.fosdem.org/2023/schedule/track/testing_and_automation/">2023</a></li>
-<li><a href="https://archive.fosdem.org/2022/schedule/track/testing_and_automation/">2022</a></li>
-<li><a href="https://archive.fosdem.org/2021/schedule/track/testing_and_automation/">2021</a></li>
-<li><a href="https://archive.fosdem.org/2020/schedule/track/testing_and_automation/">2020</a></li>
-<li><a href="https://archive.fosdem.org/2018/schedule/track/testing_and_automation/">2018</a></li>
-<li><a href="https://archive.fosdem.org/2017/schedule/track/testing_and_automation/">2017</a></li>
-<li><a href="https://archive.fosdem.org/2016/schedule/track/testing_and_automation/">2016</a></li>
-<li><a href="https://archive.fosdem.org/2015/schedule/track/testing_and_automation/">2015</a></li>
-<li><a href="https://archive.fosdem.org/2014/schedule/track/testing_and_automation/">2014</a></li>
-<li><a href="https://archive.fosdem.org/2013/schedule/track/testing_and_automation/">2013</a></li>
+<li>
+    <a href="https://archive.fosdem.org/2023/schedule/track/testing_and_automation/">Testing and Automation 2023</a>
+    <a href="https://archive.fosdem.org/2023/schedule/track/continuous_integration_and_continuous_deployment/">Continuous Integration and Continuous Deployment 2023</a>
+</li>
+<li>
+    <a href="https://archive.fosdem.org/2022/schedule/track/testing_and_automation/">Testing and Automation 2022</a>
+    <a href="https://archive.fosdem.org/2022/schedule/track/continuous_integration_and_continuous_deployment/">Continuous Integration and Continuous Deployment 2022</a>
+</li>
+<li>
+    <a href="https://archive.fosdem.org/2021/schedule/track/testing_and_automation/">Testing and Automation 2021</a>
+    <a href="https://archive.fosdem.org/2021/schedule/track/continuous_integration_and_continuous_deployment/">Continuous Integration and Continuous Deployment 2021</a>
+</li>
+<li>
+    <a href="https://archive.fosdem.org/2020/schedule/track/testing_and_automation/">Testing and Automation 2020</a>
+    <a href="https://archive.fosdem.org/2020/schedule/track/continuous_integration_and_continuous_deployment/">Continuous Integration and Continuous Deployment 2020</a>
+</li>
+<li><a href="https://archive.fosdem.org/2018/schedule/track/testing_and_automation/">Testing and Automation 2018</a></li>
+<li><a href="https://archive.fosdem.org/2017/schedule/track/testing_and_automation/">Testing and Automation 2017</a></li>
+<li><a href="https://archive.fosdem.org/2016/schedule/track/testing_and_automation/">Testing and Automation 2016</a></li>
+<li><a href="https://archive.fosdem.org/2015/schedule/track/testing_and_automation/">Testing and Automation 2015</a></li>
+<li><a href="https://archive.fosdem.org/2014/schedule/track/testing_and_automation/">Testing and Automation 2014</a></li>
+<li><a href="https://archive.fosdem.org/2013/schedule/track/testing_and_automation/">Testing and Automation 2013</a></li>
 </ul>
 
       </section>


### PR DESCRIPTION
in 2024 FOSDEM staff has decided to merge the CI/CD devroom into Testing and Automation which warrants some name & devroom managers updates.

I am also updating the Archive section with links to archives from previous years that I could find.